### PR TITLE
fix fab icon position in ios safari

### DIFF
--- a/src/lib/components/FAB.svelte
+++ b/src/lib/components/FAB.svelte
@@ -25,6 +25,7 @@
         box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.5);
         font-size: 2em;
         background: aquamarine;
+        padding: 0;
     }
 
     button:active {


### PR DESCRIPTION
Fixed position of icon in FAB for Safari browser on iOS

<img src="https://user-images.githubusercontent.com/5080574/178503324-09568e21-65fe-472e-85ad-3e2e02c3e864.PNG" alt="before bug" width="200" /> <img src="https://user-images.githubusercontent.com/5080574/178503377-147b4ef9-e672-4bc7-a745-298189111398.PNG" alt="after fix" width="200" />

